### PR TITLE
fix compiler version when version is vX.X

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -36,7 +36,13 @@ func CompilerVersion(fileName string) (string, error) {
 			if strings.Contains(line, "pragma solidity") {
 				idxStart := strings.Index(line, "0")
 				idxEnd := strings.Index(line, ";")
-				return "v" + line[idxStart:idxEnd], nil
+				
+				version := line[idxStart:idxEnd]
+				if len(version) == 3 {
+					version += ".0"
+				}
+
+				return "v" + version, nil
 			}
 		case ".vy":
 			if strings.Contains(line, "@version") {


### PR DESCRIPTION
contraget was breaking when contract version was "^0.8" as 0.8 does not exists, but only 0.8.0 exists.